### PR TITLE
Actually fix this to work after_prepare

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -20,7 +20,7 @@
         <clobbers target="window.notificationManager" />
     </js-module>
 
-    <hook type="before_compile" src="src/ios/swift-hook.js" />
+    <hook type="after_prepare" src="src/ios/swift-hook.js" />
 
     <platform name="ios">
         <config-file parent="/*" target="config.xml">

--- a/src/ios/swift-hook.js
+++ b/src/ios/swift-hook.js
@@ -3,7 +3,7 @@
 const fs = require('fs');
 
 module.exports = function(context) {
-    if (context.opts.cordova.platforms.indexOf('ios') >= 0) {
+    if (context.opts.platforms.indexOf('ios') >= 0) {
         console.warn('UPDATING the Xcode Project files');
 
         const encoding = 'utf-8';


### PR DESCRIPTION
This didn't work last time I tried it, and I think it's because I was missing the change from `context.opts.cordova.platforms` to `context.opts.platforms`