### PR TITLE
Bump some Android dependencies

### DIFF
--- a/src/android/push.gradle
+++ b/src/android/push.gradle
@@ -8,7 +8,7 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:1.1.0'
-        classpath 'com.google.gms:google-services:3.0.0'
+        classpath 'com.google.gms:google-services:3.1.1'
     }
 }
 
@@ -18,8 +18,8 @@ repositories {
 }
 
 dependencies {
-    compile 'com.google.android.gms:play-services-base:9.2.1'
-    compile 'com.google.firebase:firebase-messaging:9.2.0'
+    compile 'com.google.android.gms:play-services-base:11.8.0'
+    compile 'com.google.firebase:firebase-messaging:11.8.0'
 }
 
 apply plugin: com.google.gms.googleservices.GoogleServicesPlugin


### PR DESCRIPTION
Android 8 requires a channel to be set when posting notifications. The new Firebase SDK will handle that.