### PR TITLE
[Android] Fix gradle Firebase initialization issue

### DIFF
--- a/src/android/push.gradle
+++ b/src/android/push.gradle
@@ -12,6 +12,6 @@ buildscript {
     }
 }
 
-ext.postBuildExtras = {
+cdvPluginPostBuildExtras.add({
     apply plugin: com.google.gms.googleservices.GoogleServicesPlugin
-}
+})


### PR DESCRIPTION
ext.postBuildExtras is not an array of blocks to run, but rather a single block, and subsequent plugins can overwrite it. That appears to be what was happening here, so this `apply plugin` bit never got run.