### PR TITLE
iOS: Fix notification not showing up with the app in foreground

### DIFF
--- a/src/ios/CDVAppDelegate+Push.h
+++ b/src/ios/CDVAppDelegate+Push.h
@@ -2,13 +2,10 @@
 
 #import "Cordova/CDVAppDelegate.h"
 
-#import <UserNotifications/UserNotifications.h>
-
-@interface CDVAppDelegate (appScope)
+@interface CDVAppDelegate (push)
 
 - (void) application:(UIApplication *) application didRegisterForRemoteNotificationsWithDeviceToken: (NSData *) deviceToken;
 - (void) application:(UIApplication *) application didFailToRegisterForRemoteNotificationsWithError: (NSError *) error;
-- (void) userNotificationCenter: (UNUserNotificationCenter *) center willPresentNotification: (UNNotification *) notification withCompletionHandler: (void (^)(UNNotificationPresentationOptions options)) completionHandler;
 - (void) application:(UIApplication *) application didReceiveRemoteNotification: (NSDictionary *) userInfo fetchCompletionHandler: (void (^)(UIBackgroundFetchResult result)) completionHandler;
 
 @end

--- a/src/ios/CDVAppDelegate+Push.m
+++ b/src/ios/CDVAppDelegate+Push.m
@@ -26,8 +26,4 @@
     completionHandler(UIBackgroundFetchResultNewData);
 }
 
-- (void) userNotificationCenter: (UNUserNotificationCenter *) center willPresentNotification: (UNNotification *) notification withCompletionHandler: (void (^)(UNNotificationPresentationOptions options)) completionHandler {
-    completionHandler(UNNotificationPresentationOptionAlert | UNNotificationPresentationOptionSound);
-}
-
 @end

--- a/src/ios/PushPlugin.swift
+++ b/src/ios/PushPlugin.swift
@@ -6,7 +6,7 @@ let CDV_PushPreference      = "CordovaPushPreference";
 let CDV_PushRegistration    = "CordovaPushRegistration";
 
 @objc(CDVPushPlugin)
-class PushPlugin : CDVPlugin {
+class PushPlugin : CDVPlugin, UNUserNotificationCenterDelegate {
     private var registrationCallback : String? = nil;
     private var permissionCallback : String? = nil;
 
@@ -283,6 +283,7 @@ class PushPlugin : CDVPlugin {
 
     @objc internal func _didFinishLaunchingWithOptions(_ notification : NSNotification) {
         UIApplication.shared.applicationIconBadgeNumber = 0;
+        UNUserNotificationCenter.current().delegate = self;
 
         let options = notification.userInfo;
         if options == nil {
@@ -297,7 +298,10 @@ class PushPlugin : CDVPlugin {
                 NotificationCenter.default.post(name: NSNotification.Name.CDVPluginHandleOpenURL, object: data);
             }
         }
-        
-        UNUserNotificationCenter.current().delegate = self.appDelegate() as? UNUserNotificationCenterDelegate;
     }
+    
+    @objc internal func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+       completionHandler([.alert, .sound, .badge]);
+    }
+    
 }


### PR DESCRIPTION
It seems safe to set the plugin class as the delegate  because CDVAppDelegate doesn't implement the UNUserNotificationCenterDelegate protocol.

The delegate is now always set when the app launches too.