### PR TITLE
Android: Fix app crashing on Android 6 and implement heads up notifications

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -73,6 +73,12 @@
                     <action android:name="android.intent.action.BOOT_COMPLETED" />
                 </intent-filter>
             </receiver>
+
+            <service android:name="com.ayogo.push.MessagingService">
+              <intent-filter>
+                  <action android:name="com.google.firebase.MESSAGING_EVENT" />
+              </intent-filter>
+            </service>
         </config-file>
 
         <config-file target="AndroidManifest.xml" parent="/manifest">

--- a/src/android/com/ayogo/push/MessagingService.java
+++ b/src/android/com/ayogo/push/MessagingService.java
@@ -1,3 +1,5 @@
+// Copyright 2018 Ayogo Health Inc.
+
 package com.ayogo.push;
 
 import android.app.Notification;

--- a/src/android/com/ayogo/push/MessagingService.java
+++ b/src/android/com/ayogo/push/MessagingService.java
@@ -1,0 +1,115 @@
+package com.ayogo.push;
+
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageManager;
+import android.content.res.Resources;
+import android.os.Build;
+import android.util.Log;
+
+import com.google.firebase.messaging.FirebaseMessagingService;
+import com.google.firebase.messaging.RemoteMessage;
+
+import java.util.Map;
+import java.util.Set;
+
+public class MessagingService extends FirebaseMessagingService {
+
+    private static final String TAG = "MessagingService";
+
+    @Override
+    public void onMessageReceived(RemoteMessage remoteMessage) {
+        // Check if message contains a data payload.
+        if (remoteMessage.getData().size() > 0) {
+            sendNotification(remoteMessage);
+        }
+    }
+
+    private void sendNotification(RemoteMessage remoteMessage) {
+        PackageManager pm = getApplicationContext().getPackageManager();
+        Intent launchIntent = pm.getLaunchIntentForPackage(getApplicationContext().getPackageName());
+        String activityClassName = launchIntent != null ? launchIntent.getComponent().getClassName() : null;
+
+        if (activityClassName == null) {
+            Log.e(TAG, "Could not find activity class name");
+            return;
+        }
+
+        Intent intent = new Intent();
+        intent.setAction("push"); // This is important for the AppScope
+        intent.setClassName(getApplicationContext(), activityClassName);
+        intent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
+
+        PendingIntent pendingIntent = PendingIntent.getActivity(getApplicationContext(), 0, intent, PendingIntent.FLAG_ONE_SHOT);
+
+        ApplicationInfo applicationInfo = null;
+        Resources resources = null;
+
+        try {
+            applicationInfo = pm.getApplicationInfo(getApplicationContext().getPackageName(), PackageManager.GET_META_DATA);
+            resources = pm.getResourcesForApplication(applicationInfo);
+        } catch (PackageManager.NameNotFoundException e) {
+            Log.e(TAG, "Could not find application info or resources: " + e.getMessage());
+        }
+
+        if (resources == null) {
+            return;
+        }
+
+        String channelId = applicationInfo.metaData.getString("com.google.firebase.messaging.default_notification_channel_id");
+        int iconId = resources.getIdentifier("notification", "drawable", getApplicationContext().getPackageName());
+
+        if (iconId == 0) {
+            Log.w(TAG, "Could not find the notification icon.");
+        }
+
+        if (channelId == null) {
+            channelId = getApplicationContext().getPackageName();
+        }
+
+        /* This will configure a heads-up notification. We need to set the priority as max and also enable the vibration. */
+        Notification.Builder notificationBuilder = new Notification.Builder(this)
+                .setSmallIcon(iconId)
+                .setContentTitle(remoteMessage.getNotification().getTitle())
+                .setContentText(remoteMessage.getNotification().getBody())
+                .setPriority(Notification.PRIORITY_MAX)
+                .setAutoCancel(true)
+                .setVibrate(new long[]{0, Notification.DEFAULT_VIBRATE})
+                .setContentIntent(pendingIntent);
+
+        Map<String, String> data = remoteMessage.getData();
+
+        if (data != null) {
+            Set<String> keys = data.keySet();
+
+            for (String key : keys) {
+                intent.putExtra(key, data.get(key));
+            }
+        }
+
+        NotificationManager notificationManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
+
+        /* Since android Oreo notification channel is needed. */
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            notificationBuilder.setChannelId(channelId);
+
+            int appNameId = applicationInfo.labelRes;
+
+            String appName = appNameId == 0 ? applicationInfo.nonLocalizedLabel.toString() : getApplicationContext().getString(appNameId);
+
+            NotificationChannel channel = new NotificationChannel(channelId, appName, NotificationManager.IMPORTANCE_HIGH);
+
+            channel.enableVibration(true);
+            channel.setVibrationPattern(new long[]{0, Notification.DEFAULT_VIBRATE});
+
+            notificationManager.createNotificationChannel(channel);
+        }
+
+        notificationManager.notify(0, notificationBuilder.build());
+    }
+}

--- a/src/android/com/ayogo/push/PushPlugin.java
+++ b/src/android/com/ayogo/push/PushPlugin.java
@@ -121,7 +121,9 @@ public class PushPlugin extends CordovaPlugin
             cordova.getActivity().runOnUiThread(new Runnable() {
                 public void run() {
                     Context context = cordova.getActivity().getApplicationContext();
-                    context.startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(url)));
+                    Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
+                    intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                    context.startActivity(intent);
                 }
             });
         }


### PR DESCRIPTION
For the heads up notifications I basically followed https://github.com/firebase/quickstart-android/blob/master/messaging/app/src/main/java/com/google/firebase/quickstart/fcm/MyFirebaseMessagingService.java

I tested it on:

- Android 5 (emulator)
- Android 6 (device)
- Android 7 (device)
- Android 8 (device)
- Android P (device)

The MessagingService.onMessageReceived only executes with the app in foreground.

Regarding the app crashing on Android 6 we were getting: `“Calling startActivity() from outside of an Activity  context requires the FLAG_ACTIVITY_NEW_TASK flag.”`