### PR TITLE
Fix iOS/Xcode warnings

### DIFF
--- a/src/ios/PushPlugin.swift
+++ b/src/ios/PushPlugin.swift
@@ -44,7 +44,7 @@ class PushPlugin : CDVPlugin, UNUserNotificationCenterDelegate {
 
     /* Notification Permission ***********************************************/
 
-    func hasPermission(_ command : CDVInvokedUrlCommand) {
+    @objc func hasPermission(_ command : CDVInvokedUrlCommand) {
         var permission = UserDefaults.standard.string(forKey: CDV_PushPreference);
 
         if permission == nil {
@@ -299,9 +299,9 @@ class PushPlugin : CDVPlugin, UNUserNotificationCenterDelegate {
             }
         }
     }
-    
+
     @objc internal func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
        completionHandler([.alert, .sound, .badge]);
     }
-    
+
 }

--- a/src/ios/PushPlugin.swift
+++ b/src/ios/PushPlugin.swift
@@ -92,6 +92,19 @@ class PushPlugin : CDVPlugin, UNUserNotificationCenterDelegate {
 
                 self.permissionCallback = nil;
             }
+
+            if let callback = self.registrationCallback {
+                if granted {
+                    DispatchQueue.main.async {
+                        UIApplication.shared.registerForRemoteNotifications();
+                    }
+                } else {
+                    let result = CDVPluginResult(status: CDVCommandStatus_OK, messageAs: permission);
+                    self.commandDelegate.send(result, callbackId: callback);
+
+                    self.registrationCallback = nil;
+                }
+            }
         }
     }
 
@@ -105,7 +118,6 @@ class PushPlugin : CDVPlugin, UNUserNotificationCenterDelegate {
 
         if permission != "denied" {
             self._doRegister();
-            UIApplication.shared.registerForRemoteNotifications();
         } else {
             let result = CDVPluginResult(status: CDVCommandStatus_ERROR, messageAs:"AbortError");
             self.commandDelegate.send(result, callbackId: self.registrationCallback);

--- a/src/ios/PushPlugin.swift
+++ b/src/ios/PushPlugin.swift
@@ -67,8 +67,7 @@ class PushPlugin : CDVPlugin, UNUserNotificationCenterDelegate {
             }
 
             // Ensure that it matches the current notification settings
-            let settings = UIApplication.shared.currentUserNotificationSettings;
-            if settings != nil && settings!.types == [] && permission != "default" {
+            if let settings = UIApplication.shared.currentUserNotificationSettings, settings.types == [] && permission != "default" {
                 permission = "denied";
             }
 


### PR DESCRIPTION
(Builds on https://github.com/AyogoHealth/cordova-plugin-ayogo-push/pull/31 -- merge that first)

I haven't properly tested this yet, and I'm not 100% sure we want to set `granted` based solely on whether notifications are permitted or not (since it doesn't indicate whether remote notifications are permitted or not), but this resolves everything Xcode was giving me warnings about.