### PR TITLE
iOS fixes & set up UIBackgroundModes

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -49,6 +49,12 @@ limitations under the License.
       </feature>
     </config-file>
 
+    <config-file parent="UIBackgroundModes" target="*-Info.plist">
+      <array>
+        <string>remote-notification</string>
+      </array>
+    </config-file>
+
     <config-file parent="aps-environment" target="*/Entitlements-Debug.plist">
       <string>development</string>
     </config-file>

--- a/src/ios/PushPlugin.swift
+++ b/src/ios/PushPlugin.swift
@@ -187,18 +187,22 @@ class PushPlugin : CDVPlugin, UNUserNotificationCenterDelegate {
 
         UserDefaults.standard.set(registration, forKey:CDV_PushRegistration);
 
-        let result = CDVPluginResult(status: CDVCommandStatus_OK, messageAs:registration);
-        self.commandDelegate.send(result, callbackId: self.registrationCallback);
+        if self.registrationCallback {
+            let result = CDVPluginResult(status: CDVCommandStatus_OK, messageAs:registration);
+            self.commandDelegate.send(result, callbackId: self.registrationCallback);
 
-        self.registrationCallback = nil;
+            self.registrationCallback = nil;
+        }
     }
 
 
     @objc internal func _didFailToRegisterForRemoteNotifications(_ notification : NSNotification) {
-        let result = CDVPluginResult(status: CDVCommandStatus_ERROR, messageAs:"AbortError");
-        self.commandDelegate.send(result, callbackId: self.registrationCallback);
+        if self.registrationCallback {
+            let result = CDVPluginResult(status: CDVCommandStatus_ERROR, messageAs:"AbortError");
+            self.commandDelegate.send(result, callbackId: self.registrationCallback);
 
-        self.registrationCallback = nil;
+            self.registrationCallback = nil;
+        }
     }
 
 


### PR DESCRIPTION
* Saw a weird case on iOS10 where the `didRegisterForRemoteNotifications` was called twice with the same token, and the callback had already been consumed. If the callback has already fired, we'll ignore the event.

* iOS was saying that we needed to turn on Background Modes, so let's do that