### PR TITLE
Android Firebase Improvements

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -87,6 +87,8 @@ limitations under the License.
 
     <config-file target="AndroidManifest.xml" parent="/manifest/application">
       <meta-data android:name="com.google.android.gms.version" android:value="@integer/google_play_services_version" />
+      <meta-data android:name="google_analytics_adid_collection_enabled" android:value="false" />
+      <meta-data android:name="firebase_crash_collection_enabled" android:value="false" />
 
       <receiver android:name="com.ayogo.notification.TriggerReceiver" android:exported="false" />
       <receiver android:name="com.ayogo.notification.RestoreReceiver" android:exported="false" >

--- a/src/android/push.gradle
+++ b/src/android/push.gradle
@@ -22,8 +22,8 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
-        classpath 'com.google.gms:google-services:4.1.0'
+        classpath 'com.android.tools.build:gradle:3.3.0'
+        classpath 'com.google.gms:google-services:4.0.2'
     }
 }
 


### PR DESCRIPTION
* After updating to cordova-android@8, one of our apps was crashing with a message about needing to call `FirebaseApp. initializeApp`. This is supposed to happen automatically, but it wasn't due to a known broken version of the Google Services gradle plugin.

* It turns out there's a magic resource already pre-populated with the FCM sender ID, so we can try to read that, and fall back to the one from config.xml. If this works properly, apps won't need to specify `fcm_sender_id` as a preference anymore.

* We had some apps get removed from the Play Store due to collection of the Android Advertiser ID without it being called out in the privacy policy. I'm still not 100% sure this will fix that, but supposedly Firebase is to blame and we can turn it off with these metadata tags.
  This *might* conflict with other Cordova Firebase plugins, but we're not especially trying to be compatible with them.

TBD if this requires us to bump to a higher Firebase SDK version...