### PR TITLE
Add iOS 13 support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,3 +14,6 @@ indent_size = 4
 
 [*.swift]
 indent_size = 4
+
+[*.m]
+indent_size = 4

--- a/src/ios/CDVAppDelegate+Push.m
+++ b/src/ios/CDVAppDelegate+Push.m
@@ -24,6 +24,18 @@
         stringByReplacingOccurrencesOfString:@">" withString:@""]
         stringByReplacingOccurrencesOfString:@" " withString:@""];
 
+    if (@available(iOS 13, *)) {
+        const unsigned char *dataBuffer = (const unsigned char *)[deviceToken bytes];
+
+        NSUInteger          dataLength  = [deviceToken length];
+        NSMutableString     *hexString  = [NSMutableString stringWithCapacity:(dataLength * 2)];
+
+        for (int i = 0; i < dataLength; ++i)
+            [hexString appendString:[NSString stringWithFormat:@"%02lx", (unsigned long)dataBuffer[i]]];
+
+        token = [NSString stringWithString:hexString];
+    }
+
     [NSNotificationCenter.defaultCenter postNotificationName: @"CordovaDidRegisterForRemoteNotificationsWithDeviceToken" object: token];
 }
 

--- a/src/ios/CDVAppDelegate+Push.m
+++ b/src/ios/CDVAppDelegate+Push.m
@@ -19,22 +19,15 @@
 @implementation CDVAppDelegate (push)
 
 - (void) application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken: (NSData *) deviceToken {
-    NSString* token = [[[[deviceToken description]
-        stringByReplacingOccurrencesOfString:@"<" withString:@""]
-        stringByReplacingOccurrencesOfString:@">" withString:@""]
-        stringByReplacingOccurrencesOfString:@" " withString:@""];
+    const unsigned char *dataBuffer = (const unsigned char *)[deviceToken bytes];
 
-    if (@available(iOS 13, *)) {
-        const unsigned char *dataBuffer = (const unsigned char *)[deviceToken bytes];
+    NSUInteger          dataLength  = [deviceToken length];
+    NSMutableString     *hexString  = [NSMutableString stringWithCapacity:(dataLength * 2)];
 
-        NSUInteger          dataLength  = [deviceToken length];
-        NSMutableString     *hexString  = [NSMutableString stringWithCapacity:(dataLength * 2)];
+    for (int i = 0; i < dataLength; ++i)
+        [hexString appendString:[NSString stringWithFormat:@"%02lx", (unsigned long)dataBuffer[i]]];
 
-        for (int i = 0; i < dataLength; ++i)
-            [hexString appendString:[NSString stringWithFormat:@"%02lx", (unsigned long)dataBuffer[i]]];
-
-        token = [NSString stringWithString:hexString];
-    }
+     NSString* token = [NSString stringWithString:hexString];
 
     [NSNotificationCenter.defaultCenter postNotificationName: @"CordovaDidRegisterForRemoteNotificationsWithDeviceToken" object: token];
 }

--- a/src/ios/CDVAppDelegate+Push.m
+++ b/src/ios/CDVAppDelegate+Push.m
@@ -24,10 +24,11 @@
     NSUInteger          dataLength  = [deviceToken length];
     NSMutableString     *hexString  = [NSMutableString stringWithCapacity:(dataLength * 2)];
 
-    for (int i = 0; i < dataLength; ++i)
+    for (int i = 0; i < dataLength; ++i) {
         [hexString appendString:[NSString stringWithFormat:@"%02lx", (unsigned long)dataBuffer[i]]];
+    }
 
-     NSString* token = [NSString stringWithString:hexString];
+    NSString* token = [NSString stringWithString:hexString];
 
     [NSNotificationCenter.defaultCenter postNotificationName: @"CordovaDidRegisterForRemoteNotificationsWithDeviceToken" object: token];
 }

--- a/src/ios/PushPlugin.swift
+++ b/src/ios/PushPlugin.swift
@@ -43,7 +43,7 @@ class PushPlugin : CDVPlugin, UNUserNotificationCenterDelegate {
 
 
         // Re-register for notifications if we think we're registered
-        getPermission() { (permission) -> () in
+        _getPermission() { (permission) -> () in
             if permission == "granted" {
                 self._doRegister();
             }
@@ -62,13 +62,13 @@ class PushPlugin : CDVPlugin, UNUserNotificationCenterDelegate {
     /* Notification Permission ***********************************************/
 
     @objc func hasPermission(_ command : CDVInvokedUrlCommand) {
-        getPermission() { (permission) -> () in
+        _getPermission() { (permission) -> () in
             let result = CDVPluginResult(status: CDVCommandStatus_OK, messageAs: permission);
             self.commandDelegate.send(result, callbackId: command.callbackId);
         }
     }
 
-    func getPermission(completion: @escaping (_ result: String?) -> ()) {
+    func _getPermission(completion: @escaping (_ result: String?) -> ()) {
         var permission = UserDefaults.standard.string(forKey: CDV_PushPreference);
         if #available(iOS 10.0, *) {
             UNUserNotificationCenter.current().getNotificationSettings { (settings) in
@@ -131,7 +131,7 @@ class PushPlugin : CDVPlugin, UNUserNotificationCenterDelegate {
 
     @objc func registerPush(_ command : CDVInvokedUrlCommand) {
         self.registrationCallback = command.callbackId;
-        getPermission() { (permission) -> () in
+        _getPermission() { (permission) -> () in
             if permission != "denied" {
                 self._doRegister();
             } else {
@@ -215,18 +215,15 @@ class PushPlugin : CDVPlugin, UNUserNotificationCenterDelegate {
     /* Local Notification Scheduling *****************************************/
 
     @objc func requestPermission(_ command : CDVInvokedUrlCommand) {
-
-        getPermission() { (permission) -> () in
+        _getPermission() { (permission) -> () in
             if permission == nil {
-                       self.permissionCallback = command.callbackId;
-                       self._doRegister();
-                   } else {
-                       let result = CDVPluginResult(status: CDVCommandStatus_OK, messageAs:permission);
-                       self.commandDelegate.send(result, callbackId: command.callbackId);
-                   }
+                self.permissionCallback = command.callbackId;
+                self._doRegister();
+            } else {
+                let result = CDVPluginResult(status: CDVCommandStatus_OK, messageAs:permission);
+                self.commandDelegate.send(result, callbackId: command.callbackId);
+            }
         }
-
-
     }
 
 
@@ -240,7 +237,7 @@ class PushPlugin : CDVPlugin, UNUserNotificationCenterDelegate {
 
 
 
-        getPermission() { (permission) -> () in
+        _getPermission() { (permission) -> () in
             if permission != "granted" {
                 let result = CDVPluginResult(status: CDVCommandStatus_ERROR, messageAs:"TypeError");
                 self.commandDelegate.send(result, callbackId: command.callbackId);

--- a/src/ios/PushPlugin.swift
+++ b/src/ios/PushPlugin.swift
@@ -62,12 +62,10 @@ class PushPlugin : CDVPlugin, UNUserNotificationCenterDelegate {
     /* Notification Permission ***********************************************/
 
     @objc func hasPermission(_ command : CDVInvokedUrlCommand) {
-        _ = getPermission() { (permission) -> () in
-            print(permission as Any);
+        getPermission() { (permission) -> () in
             let result = CDVPluginResult(status: CDVCommandStatus_OK, messageAs: permission);
             self.commandDelegate.send(result, callbackId: command.callbackId);
         }
-
     }
 
     func getPermission(completion: @escaping (_ result: String?) -> ()) {


### PR DESCRIPTION
* Permissions had 2 sources of truth, user preferences and notification
manager depending on your iOS version. Add getPermission helper
to consolidate all permission access in order to maintain one
singular source of truth.

* iOS 13 has changed the contract of NSData. NSData description
no longer returns a string representation of the data. Extract
token data if iOS 13 and above.

* Spec for permission values have also changed. Notably 'default' is now 'prompt'.