### PR TITLE
AY-100: Support iOS sending NSNotification data to the application

### DIFF
--- a/src/android/push/PushPlugin.java
+++ b/src/android/push/PushPlugin.java
@@ -158,7 +158,11 @@ public class PushPlugin extends CordovaPlugin
         }
       }
 
-      this.webView.getEngine().evaluateJavascript("window.dispatchEvent(new CustomEvent('CDVnotificationClicked', { detail: "+ json +"}));", null);
+      cordova.getActivity().runOnUiThread(new Runnable() {
+        public void run() {
+            webView.getEngine().evaluateJavascript("window.dispatchEvent(new CustomEvent('CDVnotificationClicked', { detail: "+ json +"}));", null);
+        }
+      });
     }
 
     private void handlePushIntent(Intent intent) {

--- a/src/android/push/PushPlugin.java
+++ b/src/android/push/PushPlugin.java
@@ -21,6 +21,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.res.Resources;
 import android.net.Uri;
+import android.os.Bundle;
 
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GoogleApiAvailability;
@@ -30,12 +31,14 @@ import com.google.firebase.messaging.FirebaseMessaging;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaPlugin;
 import org.apache.cordova.LOG;
 import org.apache.cordova.PluginResult;
 import org.json.JSONArray;
+import org.json.JSONException;
 import org.json.JSONObject;
 
 public class PushPlugin extends CordovaPlugin
@@ -132,7 +135,30 @@ public class PushPlugin extends CordovaPlugin
 
         if(intent.getAction() != null && intent.getAction().equalsIgnoreCase("push")) {
             handlePushIntent(intent);
+            handleNotificationData(intent);
         }
+
+    }
+
+    /**
+     * Send intent extas to the application
+     * @param intent
+     */
+    private void handleNotificationData(Intent intent) {
+      JSONObject json = new JSONObject();
+      Bundle extras = intent.getExtras();
+      if (extras != null) {
+        Set<String> keys = extras.keySet();
+        for (String key : keys) {
+          try {
+            json.put(key, JSONObject.wrap(extras.get(key)));
+          } catch (JSONException e) {
+            // Do nothing for now
+          }
+        }
+      }
+
+      this.webView.getEngine().evaluateJavascript("window.dispatchEvent(new CustomEvent('CDVnotificationClicked', { detail: "+ json +"}));", null);
     }
 
     private void handlePushIntent(Intent intent) {

--- a/src/ios/CDVAppDelegate+Push.m
+++ b/src/ios/CDVAppDelegate+Push.m
@@ -43,6 +43,8 @@
         [[NSNotificationCenter defaultCenter] postNotification:[NSNotification notificationWithName:CDVPluginHandleOpenURLNotification object:url]];
     }
 
+    [[NSNotificationCenter defaultCenter] postNotification:[NSNotification notificationWithName:@"CordovaDidRecieveRemoteNotification" object:userInfo]];
+
     completionHandler(UIBackgroundFetchResultNewData);
 }
 

--- a/src/ios/CDVAppDelegate+Push.m
+++ b/src/ios/CDVAppDelegate+Push.m
@@ -43,7 +43,7 @@
         [[NSNotificationCenter defaultCenter] postNotification:[NSNotification notificationWithName:CDVPluginHandleOpenURLNotification object:url]];
     }
 
-    [[NSNotificationCenter defaultCenter] postNotification:[NSNotification notificationWithName:@"CordovaDidRecieveRemoteNotification" object:userInfo]];
+    [[NSNotificationCenter defaultCenter] postNotification:[NSNotification notificationWithName:@"CordovaDidReceiveRemoteNotification" object:userInfo]];
 
     completionHandler(UIBackgroundFetchResultNewData);
 }

--- a/src/ios/PushPlugin.swift
+++ b/src/ios/PushPlugin.swift
@@ -362,6 +362,7 @@ class PushPlugin : CDVPlugin, UNUserNotificationCenterDelegate {
         }
         if (self.pageHasLoaded) {
             self.webViewEngine.evaluateJavaScript("window.dispatchEvent(new CustomEvent('CDVnotificationClicked', { detail: '\(self.notificationData!)' }));", completionHandler: nil)
+            self.notificationData = nil;
         }
     }
 

--- a/src/ios/PushPlugin.swift
+++ b/src/ios/PushPlugin.swift
@@ -23,6 +23,8 @@ let CDV_PushRegistration    = "CordovaPushRegistration";
 class PushPlugin : CDVPlugin, UNUserNotificationCenterDelegate {
     private var registrationCallback : String? = nil;
     private var permissionCallback : String? = nil;
+    private var notificationData: String? = nil;
+    private var pageHasLoaded: Bool = false;
 
 
     override func pluginInitialize() {
@@ -38,7 +40,22 @@ class PushPlugin : CDVPlugin, UNUserNotificationCenterDelegate {
 
         NotificationCenter.default.addObserver(self,
                 selector: #selector(PushPlugin._didFinishLaunchingWithOptions(_:)),
-                name: UIApplication.didFinishLaunchingNotification,
+                name: NSNotification.Name.UIApplicationDidFinishLaunching,
+                object: nil);
+
+        NotificationCenter.default.addObserver(self,
+                selector: #selector(PushPlugin.handlePluginReset),
+                name: NSNotification.Name.CDVPluginReset,
+                object: nil);
+
+        NotificationCenter.default.addObserver(self,
+                selector: #selector(PushPlugin.handlePageLoad),
+                name: NSNotification.Name.CDVPageDidLoad,
+                object: nil);
+
+        NotificationCenter.default.addObserver(self,
+                selector: #selector(PushPlugin.handleNotificationData),
+                name: NSNotification.Name(rawValue: "CordovaDidRecieveRemoteNotification"),
                 object: nil);
 
 
@@ -329,6 +346,39 @@ class PushPlugin : CDVPlugin, UNUserNotificationCenterDelegate {
 
 
 
+    @objc internal func handlePluginReset() {
+        self.pageHasLoaded = false;
+    }
+
+    @objc internal func handleNotificationData(_ notificationData : NSNotification) {
+        guard let dataObject = notificationData.object else {
+            return;
+        }
+
+        if let notificationJSONData = try? JSONSerialization.data(withJSONObject: dataObject,options: []) {
+            let notificationTextData = String(data: notificationJSONData,
+                                       encoding: .utf8)
+            self.notificationData = notificationTextData;
+        }
+        if (self.pageHasLoaded) {
+            self.webViewEngine.evaluateJavaScript("window.dispatchEvent(new CustomEvent('CDVnotificationClicked', { detail: '\(self.notificationData!)' }));", completionHandler: nil)
+        }
+    }
+
+    @objc internal func handlePageLoad() {
+        self.pageHasLoaded = true;
+        if (self.notificationData != nil) {
+            /**
+            * In the case that the page within the webview reloads on notification clicked the dispatched event fires into oblivion.
+            * Wait 1s before dispatching the event to ensure that the page has finished loading. Listeners should be setup on an app level
+            * and not dependent on certain pages loading lots of content thus the timeout here can be as small as 0.1s.
+            */
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                self.webViewEngine.evaluateJavaScript("window.dispatchEvent(new CustomEvent('CDVnotificationClicked', { detail: '\(self.notificationData!)' }));", completionHandler: nil)
+            }
+        }
+    }
+
 
 
     /* Notification Launch URL handling **************************************/
@@ -348,7 +398,10 @@ class PushPlugin : CDVPlugin, UNUserNotificationCenterDelegate {
                 let data = NSURL(string: url);
 
                 NotificationCenter.default.post(name: NSNotification.Name.CDVPluginHandleOpenURL, object: data);
+
             }
+
+            NotificationCenter.default.post(name: NSNotification.Name(rawValue: "CordovaDidRecieveRemoteNotification"), object: options)
         }
     }
 

--- a/src/ios/PushPlugin.swift
+++ b/src/ios/PushPlugin.swift
@@ -44,18 +44,18 @@ class PushPlugin : CDVPlugin, UNUserNotificationCenterDelegate {
                 object: nil);
 
         NotificationCenter.default.addObserver(self,
-                selector: #selector(PushPlugin.handlePluginReset),
+                selector: #selector(PushPlugin._handlePluginReset),
                 name: NSNotification.Name.CDVPluginReset,
                 object: nil);
 
         NotificationCenter.default.addObserver(self,
-                selector: #selector(PushPlugin.handlePageLoad),
+                selector: #selector(PushPlugin._handlePageLoad),
                 name: NSNotification.Name.CDVPageDidLoad,
                 object: nil);
 
         NotificationCenter.default.addObserver(self,
-                selector: #selector(PushPlugin.handleNotificationData),
-                name: NSNotification.Name(rawValue: "CordovaDidRecieveRemoteNotification"),
+                selector: #selector(PushPlugin._handleNotificationData(_:)),
+                name: NSNotification.Name(rawValue: "CordovaDidReceiveRemoteNotification"),
                 object: nil);
 
 
@@ -346,11 +346,11 @@ class PushPlugin : CDVPlugin, UNUserNotificationCenterDelegate {
 
 
 
-    @objc internal func handlePluginReset() {
+    @objc internal func _handlePluginReset() {
         self.pageHasLoaded = false;
     }
 
-    @objc internal func handleNotificationData(_ notificationData : NSNotification) {
+    @objc internal func _handleNotificationData(_ notificationData : NSNotification) {
         guard let dataObject = notificationData.object else {
             return;
         }
@@ -365,7 +365,7 @@ class PushPlugin : CDVPlugin, UNUserNotificationCenterDelegate {
         }
     }
 
-    @objc internal func handlePageLoad() {
+    @objc internal func _handlePageLoad() {
         self.pageHasLoaded = true;
         if (self.notificationData != nil) {
             /**
@@ -373,8 +373,9 @@ class PushPlugin : CDVPlugin, UNUserNotificationCenterDelegate {
             * Wait 1s before dispatching the event to ensure that the page has finished loading. Listeners should be setup on an app level
             * and not dependent on certain pages loading lots of content thus the timeout here can be as small as 0.1s.
             */
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
                 self.webViewEngine.evaluateJavaScript("window.dispatchEvent(new CustomEvent('CDVnotificationClicked', { detail: '\(self.notificationData!)' }));", completionHandler: nil)
+                self.notificationData = nil;
             }
         }
     }
@@ -401,7 +402,7 @@ class PushPlugin : CDVPlugin, UNUserNotificationCenterDelegate {
 
             }
 
-            NotificationCenter.default.post(name: NSNotification.Name(rawValue: "CordovaDidRecieveRemoteNotification"), object: options)
+            NotificationCenter.default.post(name: NSNotification.Name(rawValue: "CordovaDidReceiveRemoteNotification"), object: options)
         }
     }
 

--- a/src/ios/PushPlugin.swift
+++ b/src/ios/PushPlugin.swift
@@ -361,7 +361,7 @@ class PushPlugin : CDVPlugin, UNUserNotificationCenterDelegate {
             self.notificationData = notificationTextData;
         }
         if (self.pageHasLoaded) {
-            self.webViewEngine.evaluateJavaScript("window.dispatchEvent(new CustomEvent('CDVnotificationClicked', { detail: '\(self.notificationData!)' }));", completionHandler: nil)
+            self.webViewEngine.evaluateJavaScript("window.dispatchEvent(new CustomEvent('CDVnotificationClicked', { detail: \(self.notificationData!) }));", completionHandler: nil)
             self.notificationData = nil;
         }
     }
@@ -375,7 +375,7 @@ class PushPlugin : CDVPlugin, UNUserNotificationCenterDelegate {
             * and not dependent on certain pages loading lots of content thus the timeout here can be as small as 0.1s.
             */
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                self.webViewEngine.evaluateJavaScript("window.dispatchEvent(new CustomEvent('CDVnotificationClicked', { detail: '\(self.notificationData!)' }));", completionHandler: nil)
+                self.webViewEngine.evaluateJavaScript("window.dispatchEvent(new CustomEvent('CDVnotificationClicked', { detail: \(self.notificationData!) }));", completionHandler: nil)
                 self.notificationData = nil;
             }
         }


### PR DESCRIPTION
* Dispatch a new event CordovaDidRecieveRemoteNotification to handle and parse
NSNotification data to prepare to send to the application.

*  Dispatch a new event CDVnotificationClicked on the document to send NSNotification data
to the application for further processing. It makes sense to pass throught NSNotification data
because NSNotification spec supports `custom_data` that is currently unhandled and lost by this plugin.